### PR TITLE
Add test for weird cookie names

### DIFF
--- a/demo-app/app/app.component.spec.ts
+++ b/demo-app/app/app.component.spec.ts
@@ -59,6 +59,15 @@ describe('AppComponent', () => {
     expect( cookieService.check('Foo') ).toBe( false );
   }));
 
+  it('should set and get cookies with weird names', inject([ CookieService ], ( cookieService: CookieService ) => {
+    cookieService.set( '*F.oo*', 'Bar' );
+    
+    const value = cookieService.get('*F.oo*');
+    // const value = cookieService.get('Foo');
+    
+    expect( value ).toEqual('Bar');
+  }));
+
   it('should get all cookies', inject([ CookieService ], ( cookieService: CookieService ) => {
     cookieService.set( 'Foo', 'Bar' );
     cookieService.set( 'Hello', 'World' );


### PR DESCRIPTION
The call to encodeURIComponent in line 32 of `cookie.service.ts` leaves a few characters unchanged, four of which unfortunately have a special meaning when the regexp is created in line 36. This pull request adds a test that shows the problem. I tried to add a fix using string.replace after the call to encodeURIComponent, but I can't figure out how to balance the backslashes. :/

This apparently doesn't put any backslashes in: `name = name.replace( /([.*()])/g, '\\$&' );`

This puts two backslashes in, so they just escape each other, leaving the offending character intact: `name = name.replace( /([.*()])/g, '\\\\$&' );`

References:
- [encodeURIComponent() @ MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
- [RegExp @ MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp)