### PR TITLE
Angular 4 to Angular 5

### DIFF
--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -3,7 +3,7 @@
 // Package: https://github.com/BCJTI/ng2-cookies
 
 import { Injectable, Inject } from '@angular/core';
-import { DOCUMENT } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable()
 export class CookieService {


### PR DESCRIPTION
Angular 5 documentation notes that DOCUMENT in @angular/platform-browser is depricated and that we should pull from @angular/common instead.