### PR TITLE
Fix Angular Universal crashes and improve platform identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 2.0.1
-- add support for Angular Universal
+- improve platform identification
 
 # 2.0.0
 - `package.json`: change min. requirement from Angular 4 to 4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1
+- add support for Angular Universal
+
 # 2.0.0
 - `package.json`: change min. requirement from Angular 4 to 4.2
 - `package.json`: fix `main` and `typings` references

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Please be aware that we cannot help you with problems that are out of scope. For
 
 ## Do you support Angular Universal?
 
-There is an [issue](https://github.com/7leads/ngx-cookie-service/issues/1) for that. Check out [this comment](https://github.com/7leads/ngx-cookie-service/issues/1#issuecomment-361150174) for more information about future support.
+Yes we do :)
 
 # Opening issues
 
@@ -179,6 +179,7 @@ Thanks to all contributors:
 * [kthy](https://github.com/kthy)
 * [JaredClemence](https://github.com/JaredClemence)
 * [flakolefluk](https://github.com/flakolefluk)
+* [mattbanks](https://github.com/mattbanks)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Please be aware that we cannot help you with problems that are out of scope. For
 
 ## Do you support Angular Universal?
 
-Yes we do :)
+There is an [issue](https://github.com/7leads/ngx-cookie-service/issues/1) for that. Check out [this comment](https://github.com/7leads/ngx-cookie-service/issues/1#issuecomment-361150174) for more information about future support.
 
 # Opening issues
 

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -18,8 +18,7 @@ export class CookieService {
     // Get the PLATFORM_ID so we can check if we're in a browser
     @Inject( PLATFORM_ID ) private platformId: Object
   ) {
-      // Make sure we're in a browser and not on the server, in which case `document` is accessible
-      this.documentIsAccessible = (isPlatformBrowser(this.platformId));
+    this.documentIsAccessible = isPlatformBrowser( this.platformId );
   }
 
   /**

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -2,8 +2,8 @@
 // not use `DOCUMENT` injection and therefore doesn't work well with AoT production builds.
 // Package: https://github.com/BCJTI/ng2-cookies
 
-import { Injectable, Inject } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 
 @Injectable()
 export class CookieService {
@@ -14,10 +14,12 @@ export class CookieService {
     // we will go with `any` for now to support Angular 2.4.x projects.
     // Issue: https://github.com/angular/angular/issues/12631
     // Fix: https://github.com/angular/angular/pull/14894
-    @Inject( DOCUMENT ) private document: any
+    @Inject( DOCUMENT ) private document: any,
+    // Get the PLATFORM_ID so we can check if we're in a browser
+    @Inject( PLATFORM_ID ) private platformId: Object
   ) {
-    // To avoid issues with server side prerendering, check if `document` is defined.
-    this.documentIsAccessible = document !== undefined;
+      // Make sure we're in a browser and not on the server, in which case `document` is accessible
+      this.documentIsAccessible = (isPlatformBrowser(this.platformId));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-cookie-service",
   "description": "an (aot ready) angular (4.2+) cookie service",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "author": "7leads GmbH <info@7leads.org>",
   "keywords": [


### PR DESCRIPTION
Use `isPlatformBrowser` and `PLATFORM_ID` and  to detect `document` instead of directly accessing it. This makes the package work with Angular Universal.