### PR TITLE
Add Owasp SameSite cookie params

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string ): void;
+## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: 'Lax' | 'Strict' ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );
@@ -180,6 +180,7 @@ Thanks to all contributors:
 * [JaredClemence](https://github.com/JaredClemence)
 * [flakolefluk](https://github.com/flakolefluk)
 * [mattbanks](https://github.com/mattbanks)
+* [DBaker85](https://github.com/DBaker85)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean ): void;
+## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );

--- a/README_NPM.md
+++ b/README_NPM.md
@@ -83,7 +83,7 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string ): void;
+## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: 'Lax' | 'Strict' ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );

--- a/README_NPM.md
+++ b/README_NPM.md
@@ -83,7 +83,7 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean ): void;
+## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: string ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -87,7 +87,7 @@ export class CookieService {
    * @param path     Cookie path
    * @param domain   Cookie domain
    * @param secure   Secure flag
-   * @param sameSite OWASP samesite token `lax` or `strict`
+   * @param sameSite OWASP samesite token `Lax` or `Strict`
    */
   set(
     name: string,
@@ -126,7 +126,7 @@ export class CookieService {
       cookieString += 'secure;';
     }
 
-    if (sameSite) {
+    if ( sameSite ) {
       cookieString += 'sameSite=' + sameSite + ';';
     }
 

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -14,26 +14,26 @@ export class CookieService {
     // we will go with `any` for now to support Angular 2.4.x projects.
     // Issue: https://github.com/angular/angular/issues/12631
     // Fix: https://github.com/angular/angular/pull/14894
-    @Inject(DOCUMENT) private document: any,
+    @Inject( DOCUMENT ) private document: any,
     // Get the `PLATFORM_ID` so we can check if we're in a browser.
-    @Inject(PLATFORM_ID) private platformId: InjectionToken<Object>
+    @Inject( PLATFORM_ID ) private platformId: InjectionToken<Object>,
   ) {
-    this.documentIsAccessible = isPlatformBrowser(this.platformId);
+    this.documentIsAccessible = isPlatformBrowser( this.platformId );
   }
 
   /**
    * @param name Cookie name
    * @returns {boolean}
    */
-  check(name: string): boolean {
-    if (!this.documentIsAccessible) {
+  check( name: string ): boolean {
+    if ( !this.documentIsAccessible ) {
       return false;
     }
 
-    name = encodeURIComponent(name);
+    name = encodeURIComponent( name );
 
-    const regExp: RegExp = this.getCookieRegExp(name);
-    const exists: boolean = regExp.test(this.document.cookie);
+    const regExp: RegExp = this.getCookieRegExp( name );
+    const exists: boolean = regExp.test( this.document.cookie );
 
     return exists;
   }
@@ -42,14 +42,14 @@ export class CookieService {
    * @param name Cookie name
    * @returns {any}
    */
-  get(name: string): string {
-    if (this.documentIsAccessible && this.check(name)) {
-      name = encodeURIComponent(name);
+  get( name: string ): string {
+    if ( this.documentIsAccessible && this.check( name ) ) {
+      name = encodeURIComponent( name );
 
-      const regExp: RegExp = this.getCookieRegExp(name);
-      const result: RegExpExecArray = regExp.exec(this.document.cookie);
+      const regExp: RegExp = this.getCookieRegExp( name );
+      const result: RegExpExecArray = regExp.exec( this.document.cookie );
 
-      return decodeURIComponent(result[1]);
+      return decodeURIComponent( result[ 1 ] );
     } else {
       return '';
     }
@@ -59,23 +59,21 @@ export class CookieService {
    * @returns {}
    */
   getAll(): {} {
-    if (!this.documentIsAccessible) {
+    if ( !this.documentIsAccessible ) {
       return {};
     }
 
     const cookies: {} = {};
     const document: any = this.document;
 
-    if (document.cookie && document.cookie !== '') {
+    if ( document.cookie && document.cookie !== '' ) {
       const split: Array<string> = document.cookie.split(';');
 
-      for (let i = 0; i < split.length; i += 1) {
-        const currentCookie: Array<string> = split[i].split('=');
+      for ( let i = 0; i < split.length; i += 1 ) {
+        const currentCookie: Array<string> = split[ i ].split('=');
 
-        currentCookie[0] = currentCookie[0].replace(/^ /, '');
-        cookies[decodeURIComponent(currentCookie[0])] = decodeURIComponent(
-          currentCookie[1]
-        );
+        currentCookie[ 0 ] = currentCookie[ 0 ].replace( /^ /, '' );
+        cookies[ decodeURIComponent( currentCookie[ 0 ] ) ] = decodeURIComponent( currentCookie[ 1 ] );
       }
     }
 
@@ -83,8 +81,8 @@ export class CookieService {
   }
 
   /**
-   * @param value    Cookie value
    * @param name     Cookie name
+   * @param value    Cookie value
    * @param expires  Number of days until the cookies expires or an actual `Date`
    * @param path     Cookie path
    * @param domain   Cookie domain
@@ -98,20 +96,17 @@ export class CookieService {
     path?: string,
     domain?: string,
     secure?: boolean,
-    sameSite?: string
+    sameSite?: 'Lax' | 'Strict'
   ): void {
-    if (!this.documentIsAccessible) {
+    if ( !this.documentIsAccessible ) {
       return;
     }
 
-    let cookieString: string =
-      encodeURIComponent(name) + '=' + encodeURIComponent(value) + ';';
+    let cookieString: string = encodeURIComponent( name ) + '=' + encodeURIComponent( value ) + ';';
 
-    if (expires) {
-      if (typeof expires === 'number') {
-        const dateExpires: Date = new Date(
-          new Date().getTime() + expires * 1000 * 60 * 60 * 24
-        );
+    if ( expires ) {
+      if ( typeof expires === 'number' ) {
+        const dateExpires: Date = new Date( new Date().getTime() + expires * 1000 * 60 * 60 * 24 );
 
         cookieString += 'expires=' + dateExpires.toUTCString() + ';';
       } else {
@@ -119,20 +114,20 @@ export class CookieService {
       }
     }
 
-    if (path) {
+    if ( path ) {
       cookieString += 'path=' + path + ';';
     }
 
-    if (domain) {
+    if ( domain ) {
       cookieString += 'domain=' + domain + ';';
     }
 
-    if (secure) {
+    if ( secure ) {
       cookieString += 'secure;';
     }
 
     if (sameSite) {
-      cookieString += 'SameSite=' + sameSite + ';';
+      cookieString += 'sameSite=' + sameSite + ';';
     }
 
     this.document.cookie = cookieString;
@@ -143,28 +138,28 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete(name: string, path?: string, domain?: string): void {
-    if (!this.documentIsAccessible) {
+  delete( name: string, path?: string, domain?: string ): void {
+    if ( !this.documentIsAccessible ) {
       return;
     }
 
-    this.set(name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain);
+    this.set( name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain );
   }
 
   /**
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  deleteAll(path?: string, domain?: string): void {
-    if (!this.documentIsAccessible) {
+  deleteAll( path?: string, domain?: string ): void {
+    if ( !this.documentIsAccessible ) {
       return;
     }
 
     const cookies: any = this.getAll();
 
-    for (const cookieName in cookies) {
-      if (cookies.hasOwnProperty(cookieName)) {
-        this.delete(cookieName, path, domain);
+    for ( const cookieName in cookies ) {
+      if ( cookies.hasOwnProperty( cookieName ) ) {
+        this.delete( cookieName, path, domain );
       }
     }
   }
@@ -173,15 +168,9 @@ export class CookieService {
    * @param name Cookie name
    * @returns {RegExp}
    */
-  private getCookieRegExp(name: string): RegExp {
-    const escapedName: string = name.replace(
-      /([\[\]\{\}\(\)\|\=\;\+\?\,\.\*\^\$])/gi,
-      '\\$1'
-    );
+  private getCookieRegExp( name: string ): RegExp {
+    const escapedName: string = name.replace( /([\[\]\{\}\(\)\|\=\;\+\?\,\.\*\^\$])/ig, '\\$1' );
 
-    return new RegExp(
-      '(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)',
-      'g'
-    );
+    return new RegExp( '(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)', 'g' );
   }
 }

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -14,26 +14,26 @@ export class CookieService {
     // we will go with `any` for now to support Angular 2.4.x projects.
     // Issue: https://github.com/angular/angular/issues/12631
     // Fix: https://github.com/angular/angular/pull/14894
-    @Inject( DOCUMENT ) private document: any,
+    @Inject(DOCUMENT) private document: any,
     // Get the `PLATFORM_ID` so we can check if we're in a browser.
-    @Inject( PLATFORM_ID ) private platformId: InjectionToken<Object>,
+    @Inject(PLATFORM_ID) private platformId: InjectionToken<Object>
   ) {
-    this.documentIsAccessible = isPlatformBrowser( this.platformId );
+    this.documentIsAccessible = isPlatformBrowser(this.platformId);
   }
 
   /**
    * @param name Cookie name
    * @returns {boolean}
    */
-  check( name: string ): boolean {
-    if ( !this.documentIsAccessible ) {
+  check(name: string): boolean {
+    if (!this.documentIsAccessible) {
       return false;
     }
 
-    name = encodeURIComponent( name );
+    name = encodeURIComponent(name);
 
-    const regExp: RegExp = this.getCookieRegExp( name );
-    const exists: boolean = regExp.test( this.document.cookie );
+    const regExp: RegExp = this.getCookieRegExp(name);
+    const exists: boolean = regExp.test(this.document.cookie);
 
     return exists;
   }
@@ -42,14 +42,14 @@ export class CookieService {
    * @param name Cookie name
    * @returns {any}
    */
-  get( name: string ): string {
-    if ( this.documentIsAccessible && this.check( name ) ) {
-      name = encodeURIComponent( name );
+  get(name: string): string {
+    if (this.documentIsAccessible && this.check(name)) {
+      name = encodeURIComponent(name);
 
-      const regExp: RegExp = this.getCookieRegExp( name );
-      const result: RegExpExecArray = regExp.exec( this.document.cookie );
+      const regExp: RegExp = this.getCookieRegExp(name);
+      const result: RegExpExecArray = regExp.exec(this.document.cookie);
 
-      return decodeURIComponent( result[ 1 ] );
+      return decodeURIComponent(result[1]);
     } else {
       return '';
     }
@@ -59,21 +59,23 @@ export class CookieService {
    * @returns {}
    */
   getAll(): {} {
-    if ( !this.documentIsAccessible ) {
+    if (!this.documentIsAccessible) {
       return {};
     }
 
     const cookies: {} = {};
     const document: any = this.document;
 
-    if ( document.cookie && document.cookie !== '' ) {
+    if (document.cookie && document.cookie !== '') {
       const split: Array<string> = document.cookie.split(';');
 
-      for ( let i = 0; i < split.length; i += 1 ) {
-        const currentCookie: Array<string> = split[ i ].split('=');
+      for (let i = 0; i < split.length; i += 1) {
+        const currentCookie: Array<string> = split[i].split('=');
 
-        currentCookie[ 0 ] = currentCookie[ 0 ].replace( /^ /, '' );
-        cookies[ decodeURIComponent( currentCookie[ 0 ] ) ] = decodeURIComponent( currentCookie[ 1 ] );
+        currentCookie[0] = currentCookie[0].replace(/^ /, '');
+        cookies[decodeURIComponent(currentCookie[0])] = decodeURIComponent(
+          currentCookie[1]
+        );
       }
     }
 
@@ -81,12 +83,13 @@ export class CookieService {
   }
 
   /**
-   * @param name    Cookie name
-   * @param value   Cookie value
-   * @param expires Number of days until the cookies expires or an actual `Date`
-   * @param path    Cookie path
-   * @param domain  Cookie domain
-   * @param secure  Secure flag
+   * @param value    Cookie value
+   * @param name     Cookie name
+   * @param expires  Number of days until the cookies expires or an actual `Date`
+   * @param path     Cookie path
+   * @param domain   Cookie domain
+   * @param secure   Secure flag
+   * @param sameSite OWASP samesite token `lax` or `strict`
    */
   set(
     name: string,
@@ -94,17 +97,21 @@ export class CookieService {
     expires?: number | Date,
     path?: string,
     domain?: string,
-    secure?: boolean
+    secure?: boolean,
+    sameSite?: string
   ): void {
-    if ( !this.documentIsAccessible ) {
+    if (!this.documentIsAccessible) {
       return;
     }
 
-    let cookieString: string = encodeURIComponent( name ) + '=' + encodeURIComponent( value ) + ';';
+    let cookieString: string =
+      encodeURIComponent(name) + '=' + encodeURIComponent(value) + ';';
 
-    if ( expires ) {
-      if ( typeof expires === 'number' ) {
-        const dateExpires: Date = new Date( new Date().getTime() + expires * 1000 * 60 * 60 * 24 );
+    if (expires) {
+      if (typeof expires === 'number') {
+        const dateExpires: Date = new Date(
+          new Date().getTime() + expires * 1000 * 60 * 60 * 24
+        );
 
         cookieString += 'expires=' + dateExpires.toUTCString() + ';';
       } else {
@@ -112,16 +119,20 @@ export class CookieService {
       }
     }
 
-    if ( path ) {
+    if (path) {
       cookieString += 'path=' + path + ';';
     }
 
-    if ( domain ) {
+    if (domain) {
       cookieString += 'domain=' + domain + ';';
     }
 
-    if ( secure ) {
+    if (secure) {
       cookieString += 'secure;';
+    }
+
+    if (sameSite) {
+      cookieString += 'SameSite=' + sameSite + ';';
     }
 
     this.document.cookie = cookieString;
@@ -132,28 +143,28 @@ export class CookieService {
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  delete( name: string, path?: string, domain?: string ): void {
-    if ( !this.documentIsAccessible ) {
+  delete(name: string, path?: string, domain?: string): void {
+    if (!this.documentIsAccessible) {
       return;
     }
 
-    this.set( name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain );
+    this.set(name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain);
   }
 
   /**
    * @param path   Cookie path
    * @param domain Cookie domain
    */
-  deleteAll( path?: string, domain?: string ): void {
-    if ( !this.documentIsAccessible ) {
+  deleteAll(path?: string, domain?: string): void {
+    if (!this.documentIsAccessible) {
       return;
     }
 
     const cookies: any = this.getAll();
 
-    for ( const cookieName in cookies ) {
-      if ( cookies.hasOwnProperty( cookieName ) ) {
-        this.delete( cookieName, path, domain );
+    for (const cookieName in cookies) {
+      if (cookies.hasOwnProperty(cookieName)) {
+        this.delete(cookieName, path, domain);
       }
     }
   }
@@ -162,9 +173,15 @@ export class CookieService {
    * @param name Cookie name
    * @returns {RegExp}
    */
-  private getCookieRegExp( name: string ): RegExp {
-    const escapedName: string = name.replace( /([\[\]\{\}\(\)\|\=\;\+\?\,\.\*\^\$])/ig, '\\$1' );
+  private getCookieRegExp(name: string): RegExp {
+    const escapedName: string = name.replace(
+      /([\[\]\{\}\(\)\|\=\;\+\?\,\.\*\^\$])/gi,
+      '\\$1'
+    );
 
-    return new RegExp( '(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)', 'g' );
+    return new RegExp(
+      '(?:^' + escapedName + '|;\\s*' + escapedName + ')=(.*?)(?:;|$)',
+      'g'
+    );
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     },
     {
       "name": "mattbanks"
+    },
+    {
+      "name": "DBaker85"
     }
   ],
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "protractor": "~5.1.0",
     "rimraf": "^2.6.1",
     "rxjs": "^5.1.0",
-    "ts-node": "~2.0.0",
+    "ts-node": "~3.3.0",
     "tslint": "~4.5.0",
     "typescript": "~2.2.0",
     "zone.js": "^0.8.4"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "protractor": "~5.1.0",
     "rimraf": "^2.6.1",
     "rxjs": "^5.1.0",
-    "ts-node": "~3.3.0",
+    "ts-node": "~2.0.0",
     "tslint": "~4.5.0",
     "typescript": "~2.2.0",
     "zone.js": "^0.8.4"

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -8,101 +8,88 @@ const exec = require('child_process').exec;
 
 console.log('Preparing ngx-cookie-service for `npm publish`...');
 
-async.waterfall(
-  [
-    deleteDistFolder,
-    makeNewDistFolder,
-    compileTypeScriptAndCreateDefinitionFile,
-    copyPackageJson,
-    copyNpmReadme
-  ],
-  function(err, result) {
-    if (err) {
-      throw new Error(err);
-    } else {
-      console.log('Ready to publish!');
-    }
+async.waterfall([
+  deleteDistFolder,
+  makeNewDistFolder,
+  compileTypeScriptAndCreateDefinitionFile,
+  copyPackageJson,
+  copyNpmReadme
+], function( err, result ) {
+  if ( err ) {
+    throw new Error( err );
+  } else {
+    console.log('Ready to publish!');
   }
-);
+});
 
-function deleteDistFolder(next) {
-  rimraf(path.join(__dirname, '..', 'dist-lib'), function(err) {
-    if (err) {
+function deleteDistFolder( next ) {
+  rimraf( path.join( __dirname, '..', 'dist-lib' ), function( err ) {
+    if ( err ) {
       console.log('Could not delete `dist-lib`...');
-      next(err);
+      next( err );
     } else {
       console.log('Deleted `dist-lib`...');
-      next(null);
+      next( null );
     }
   });
 }
 
-function makeNewDistFolder(next) {
-  fs.mkdir(path.join(__dirname, '..', 'dist-lib'), function(err) {
-    if (err) {
+function makeNewDistFolder( next ) {
+  fs.mkdir( path.join( __dirname, '..', 'dist-lib' ), function( err ) {
+    if ( err ) {
       console.log('Could not create `dist-lib`...');
-      next(err);
+      next( err );
     } else {
       console.log('Created `dist-lib`...');
-      next(null);
+      next( null );
     }
   });
 }
 
-function compileTypeScriptAndCreateDefinitionFile(next) {
-  const cookieServicePath = path.join(__dirname, '..', 'lib');
-  const ngcPath = path.join(__dirname, '..', 'node_modules', '.bin', 'ngc');
-  exec(ngcPath + ' -p ' + cookieServicePath, function(err) {
-    if (err) {
+function compileTypeScriptAndCreateDefinitionFile( next ) {
+  const cookieServicePath = path.join( __dirname, '..', 'lib' );
+  const ngcPath = path.join( __dirname, '..', 'node_modules', '.bin', 'ngc' )
+  exec( ngcPath + ' -p ' + cookieServicePath, function( err ) {
+    if ( err ) {
       console.log('Failed to compile cookie service...');
-      next(err);
+      next( err );
     } else {
       console.log('Successfully compiled cookie service...');
-      next(null);
+      next( null );
     }
   });
 }
 
-function copyPackageJson(next) {
-  const packageJsonPath = path.join(__dirname, '..', 'package.json');
-  const distLibPackageJsonPath = path.join(
-    __dirname,
-    '..',
-    'dist-lib',
-    'package.json'
-  );
-  const source = fs.createReadStream(packageJsonPath);
-  const dest = fs.createWriteStream(distLibPackageJsonPath);
+function copyPackageJson( next ) {
+  const packageJsonPath = path.join( __dirname, '..', 'package.json' );
+  const distLibPackageJsonPath = path.join( __dirname, '..', 'dist-lib', 'package.json' );
+  const source = fs.createReadStream( packageJsonPath );
+  const dest = fs.createWriteStream( distLibPackageJsonPath );
 
-  source.pipe(dest);
-  source.on('error', function(err) {
+  source.pipe( dest );
+  source.on('error', function( err ) {
     console.log('Failed to copy package.json...');
-    next(err);
+    next( err );
   });
   source.on('end', function() {
     console.log('Successfully copied package.json...');
-    next(null);
+    next( null );
   });
 }
 
-function copyNpmReadme(next) {
-  const packageJsonPath = path.join(__dirname, '..', 'README_NPM.md');
-  const distLibPackageJsonPath = path.join(
-    __dirname,
-    '..',
-    'dist-lib',
-    'README.md'
-  );
-  const source = fs.createReadStream(packageJsonPath);
-  const dest = fs.createWriteStream(distLibPackageJsonPath);
+function copyNpmReadme( next ) {
+  const packageJsonPath = path.join( __dirname, '..', 'README_NPM.md' );
+  const distLibPackageJsonPath = path.join( __dirname, '..', 'dist-lib', 'README.md' );
+  const source = fs.createReadStream( packageJsonPath );
+  const dest = fs.createWriteStream( distLibPackageJsonPath );
 
-  source.pipe(dest);
-  source.on('error', function(err) {
+  source.pipe( dest );
+  source.on('error', function( err ) {
     console.log('Failed to copy README_NPM.md...');
-    next(err);
+    next( err );
   });
   source.on('end', function() {
     console.log('Successfully copied README_NPM.md as README.md...');
-    next(null);
+    next( null );
   });
 }

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -23,7 +23,7 @@ async.waterfall([
 });
 
 function deleteDistFolder( next ) {
-  rimraf( path.join( __dirname, '..', 'dist-lib' ), function( err ) {
+  rimraf( path.join( __dirname, '../dist-lib' ), function( err ) {
     if ( err ) {
       console.log('Could not delete `dist-lib`...');
       next( err );
@@ -35,7 +35,7 @@ function deleteDistFolder( next ) {
 }
 
 function makeNewDistFolder( next ) {
-  fs.mkdir( path.join( __dirname, '..', 'dist-lib' ), function( err ) {
+  fs.mkdir( path.join( __dirname, '../dist-lib' ), function( err ) {
     if ( err ) {
       console.log('Could not create `dist-lib`...');
       next( err );
@@ -47,9 +47,8 @@ function makeNewDistFolder( next ) {
 }
 
 function compileTypeScriptAndCreateDefinitionFile( next ) {
-  const cookieServicePath = path.join( __dirname, '..', 'lib' );
-  const ngcPath = path.join( __dirname, '..', 'node_modules', '.bin', 'ngc' )
-  exec( ngcPath + ' -p ' + cookieServicePath, function( err ) {
+  const cookieServicePath = path.join( __dirname, '../lib' );
+  exec( 'node_modules/.bin/ngc -p ' + cookieServicePath, function( err ) {
     if ( err ) {
       console.log('Failed to compile cookie service...');
       next( err );
@@ -61,8 +60,8 @@ function compileTypeScriptAndCreateDefinitionFile( next ) {
 }
 
 function copyPackageJson( next ) {
-  const packageJsonPath = path.join( __dirname, '..', 'package.json' );
-  const distLibPackageJsonPath = path.join( __dirname, '..', 'dist-lib', 'package.json' );
+  const packageJsonPath = path.join( __dirname, '../package.json' );
+  const distLibPackageJsonPath = path.join( __dirname, '../dist-lib/package.json' );
   const source = fs.createReadStream( packageJsonPath );
   const dest = fs.createWriteStream( distLibPackageJsonPath );
 
@@ -78,8 +77,8 @@ function copyPackageJson( next ) {
 }
 
 function copyNpmReadme( next ) {
-  const packageJsonPath = path.join( __dirname, '..', 'README_NPM.md' );
-  const distLibPackageJsonPath = path.join( __dirname, '..', 'dist-lib', 'README.md' );
+  const packageJsonPath = path.join( __dirname, '../README_NPM.md' );
+  const distLibPackageJsonPath = path.join( __dirname, '../dist-lib/README.md' );
   const source = fs.createReadStream( packageJsonPath );
   const dest = fs.createWriteStream( distLibPackageJsonPath );
 

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -8,87 +8,101 @@ const exec = require('child_process').exec;
 
 console.log('Preparing ngx-cookie-service for `npm publish`...');
 
-async.waterfall([
-  deleteDistFolder,
-  makeNewDistFolder,
-  compileTypeScriptAndCreateDefinitionFile,
-  copyPackageJson,
-  copyNpmReadme
-], function( err, result ) {
-  if ( err ) {
-    throw new Error( err );
-  } else {
-    console.log('Ready to publish!');
+async.waterfall(
+  [
+    deleteDistFolder,
+    makeNewDistFolder,
+    compileTypeScriptAndCreateDefinitionFile,
+    copyPackageJson,
+    copyNpmReadme
+  ],
+  function(err, result) {
+    if (err) {
+      throw new Error(err);
+    } else {
+      console.log('Ready to publish!');
+    }
   }
-});
+);
 
-function deleteDistFolder( next ) {
-  rimraf( path.join( __dirname, '../dist-lib' ), function( err ) {
-    if ( err ) {
+function deleteDistFolder(next) {
+  rimraf(path.join(__dirname, '..', 'dist-lib'), function(err) {
+    if (err) {
       console.log('Could not delete `dist-lib`...');
-      next( err );
+      next(err);
     } else {
       console.log('Deleted `dist-lib`...');
-      next( null );
+      next(null);
     }
   });
 }
 
-function makeNewDistFolder( next ) {
-  fs.mkdir( path.join( __dirname, '../dist-lib' ), function( err ) {
-    if ( err ) {
+function makeNewDistFolder(next) {
+  fs.mkdir(path.join(__dirname, '..', 'dist-lib'), function(err) {
+    if (err) {
       console.log('Could not create `dist-lib`...');
-      next( err );
+      next(err);
     } else {
       console.log('Created `dist-lib`...');
-      next( null );
+      next(null);
     }
   });
 }
 
-function compileTypeScriptAndCreateDefinitionFile( next ) {
-  const cookieServicePath = path.join( __dirname, '../lib' );
-  exec( 'node_modules/.bin/ngc -p ' + cookieServicePath, function( err ) {
-    if ( err ) {
+function compileTypeScriptAndCreateDefinitionFile(next) {
+  const cookieServicePath = path.join(__dirname, '..', 'lib');
+  const ngcPath = path.join(__dirname, '..', 'node_modules', '.bin', 'ngc');
+  exec(ngcPath + ' -p ' + cookieServicePath, function(err) {
+    if (err) {
       console.log('Failed to compile cookie service...');
-      next( err );
+      next(err);
     } else {
       console.log('Successfully compiled cookie service...');
-      next( null );
+      next(null);
     }
   });
 }
 
-function copyPackageJson( next ) {
-  const packageJsonPath = path.join( __dirname, '../package.json' );
-  const distLibPackageJsonPath = path.join( __dirname, '../dist-lib/package.json' );
-  const source = fs.createReadStream( packageJsonPath );
-  const dest = fs.createWriteStream( distLibPackageJsonPath );
+function copyPackageJson(next) {
+  const packageJsonPath = path.join(__dirname, '..', 'package.json');
+  const distLibPackageJsonPath = path.join(
+    __dirname,
+    '..',
+    'dist-lib',
+    'package.json'
+  );
+  const source = fs.createReadStream(packageJsonPath);
+  const dest = fs.createWriteStream(distLibPackageJsonPath);
 
-  source.pipe( dest );
-  source.on('error', function( err ) {
+  source.pipe(dest);
+  source.on('error', function(err) {
     console.log('Failed to copy package.json...');
-    next( err );
+    next(err);
   });
   source.on('end', function() {
     console.log('Successfully copied package.json...');
-    next( null );
+    next(null);
   });
 }
 
-function copyNpmReadme( next ) {
-  const packageJsonPath = path.join( __dirname, '../README_NPM.md' );
-  const distLibPackageJsonPath = path.join( __dirname, '../dist-lib/README.md' );
-  const source = fs.createReadStream( packageJsonPath );
-  const dest = fs.createWriteStream( distLibPackageJsonPath );
+function copyNpmReadme(next) {
+  const packageJsonPath = path.join(__dirname, '..', 'README_NPM.md');
+  const distLibPackageJsonPath = path.join(
+    __dirname,
+    '..',
+    'dist-lib',
+    'README.md'
+  );
+  const source = fs.createReadStream(packageJsonPath);
+  const dest = fs.createWriteStream(distLibPackageJsonPath);
 
-  source.pipe( dest );
-  source.on('error', function( err ) {
+  source.pipe(dest);
+  source.on('error', function(err) {
     console.log('Failed to copy README_NPM.md...');
-    next( err );
+    next(err);
   });
   source.on('end', function() {
     console.log('Successfully copied README_NPM.md as README.md...');
-    next( null );
+    next(null);
   });
 }


### PR DESCRIPTION
Many sites now require the Samesite cookie Param for secure requests.

[https://www.owasp.org/index.php/SameSite](https://www.owasp.org/index.php/SameSite)

This PR 
- adds the Owasp required `sameSite` cookie parameter.
- fixes paths to work cross environment by splitting each segment of path.
- fixes e2e with a newer version of ts-node