### PR TITLE
Addition of CookieOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Thanks to all contributors:
 * [flakolefluk](https://github.com/flakolefluk)
 * [mattbanks](https://github.com/mattbanks)
 * [DBaker85](https://github.com/DBaker85)
+* [alessioferrero](https://github.com/alessioferrero)
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -89,13 +89,15 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: 'Lax' | 'Strict' ): void;
+## set( name: string, value: string, options?: CookieOptions ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );
 ```
 
 Sets a cookie with the specified `name` and `value`. It is good practice to specify a path. If you are unsure about the path value, use `'/'`. If no path or domain is explicitly defined, the current location is assumed.
+
+For further details on [CookieOptions, please see the 'Interfaces' section below](#Interfaces)
 
 **Important:** For security reasons, it is not possible to define cookies for other domains. Browsers do not allow this. Read [this](https://stackoverflow.com/a/1063760) and [this](https://stackoverflow.com/a/17777005/1007003) StackOverflow answer for a more in-depth explanation.
 
@@ -116,6 +118,21 @@ cookieService.deleteAll();
 ```
 
 Deletes all cookies that can currently be accessed. It is best practice to always define a path. If you are unsure about the path value, use `'/'`.
+
+# Interfaces
+
+## CookieOptions
+
+```typescript
+const options: CookieOptions = {
+  // Expires in 7 days
+  expires: 7,
+  path: '/',
+  domain: '.my-test-site.com',
+  secure: true,
+  sameSite: 'Strict'
+};
+```
 
 # FAQ
 

--- a/README_NPM.md
+++ b/README_NPM.md
@@ -83,13 +83,15 @@ const allCookies: {} = cookieService.getAll();
 
 Returns a map of key-value pairs for cookies that can be accessed.
 
-## set( name: string, value: string, expires?: number | Date, path?: string, domain?: string, secure?: boolean, sameSite?: 'Lax' | 'Strict' ): void;
+## set( name: string, value: string, options?: CookieOptions ): void;
 
 ```typescript
 cookieService.set( 'test', 'Hello World' );
 ```
 
 Sets a cookie with the specified `name` and `value`. It is good practice to specify a path. If you are unsure about the path value, use `'/'`. If no path or domain is explicitly defined, the current location is assumed.
+
+For further details on [CookieOptions, please see the 'Interfaces' section below](#Interfaces)
 
 **Important:** For security reasons, it is not possible to define cookies for other domains. Browsers do not allow this. Read [this](https://stackoverflow.com/a/1063760) and [this](https://stackoverflow.com/a/17777005/1007003) StackOverflow answer for a more in-depth explanation.
 
@@ -110,6 +112,21 @@ cookieService.deleteAll();
 ```
 
 Deletes all cookies that can currently be accessed. It is best practice to always define a path. If you are unsure about the path value, use `'/'`.
+
+# Interfaces
+
+## CookieOptions
+
+```typescript
+const options: CookieOptions = {
+  // Expires in 7 days
+  expires: 7,
+  path: '/',
+  domain: '.my-test-site.com',
+  secure: true,
+  sameSite: 'Strict'
+};
+```
 
 # FAQ & Troubleshooting
 

--- a/lib/cookie-service/cookie-options.model.ts
+++ b/lib/cookie-service/cookie-options.model.ts
@@ -1,0 +1,20 @@
+/**
+ * @name CookieOptions
+ * @description Interface for declaring the options of a cookie
+ *
+ * This interface contains the following optional properties:
+ *
+ * - **expires** - {number | Date} - Number of days until the cookies expires or an actual `Date`
+ * - **path** - {string} - The cookie will only be available for this URL and all subdirectories
+ * - **domain** - {string} - The cookie will only be available to this domain and its subdomains
+ * - **secure** - {boolean} - When set to true, the cookie can only be transmitted over HTTPS
+ * - **sameSite** - {'Lax' | 'Strict'} - When set to `Strict` the browser will not send this
+ *   cookie along with cross-site requests
+ */
+export interface CookieOptions {
+  expires?: number | Date;
+  path?: string;
+  domain?: string;
+  secure?: boolean;
+  sameSite?: 'Lax' | 'Strict';
+}

--- a/lib/cookie-service/cookie.service.ts
+++ b/lib/cookie-service/cookie.service.ts
@@ -4,6 +4,7 @@
 
 import { Injectable, Inject, PLATFORM_ID, InjectionToken } from '@angular/core';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { CookieOptions } from './cookie-options.model';
 
 @Injectable()
 export class CookieService {
@@ -83,20 +84,12 @@ export class CookieService {
   /**
    * @param name     Cookie name
    * @param value    Cookie value
-   * @param expires  Number of days until the cookies expires or an actual `Date`
-   * @param path     Cookie path
-   * @param domain   Cookie domain
-   * @param secure   Secure flag
-   * @param sameSite OWASP samesite token `Lax` or `Strict`
+   * @param options  Cookie options
    */
   set(
     name: string,
     value: string,
-    expires?: number | Date,
-    path?: string,
-    domain?: string,
-    secure?: boolean,
-    sameSite?: 'Lax' | 'Strict'
+    options?: CookieOptions
   ): void {
     if ( !this.documentIsAccessible ) {
       return;
@@ -104,30 +97,32 @@ export class CookieService {
 
     let cookieString: string = encodeURIComponent( name ) + '=' + encodeURIComponent( value ) + ';';
 
-    if ( expires ) {
-      if ( typeof expires === 'number' ) {
-        const dateExpires: Date = new Date( new Date().getTime() + expires * 1000 * 60 * 60 * 24 );
+    if ( options ) {
+      if ( options.expires ) {
+        if ( typeof options.expires === 'number' ) {
+          const dateExpires: Date = new Date( new Date().getTime() + options.expires * 1000 * 60 * 60 * 24 );
 
-        cookieString += 'expires=' + dateExpires.toUTCString() + ';';
-      } else {
-        cookieString += 'expires=' + expires.toUTCString() + ';';
+          cookieString += 'expires=' + dateExpires.toUTCString() + ';';
+        } else {
+          cookieString += 'expires=' + options.expires.toUTCString() + ';';
+        }
       }
-    }
 
-    if ( path ) {
-      cookieString += 'path=' + path + ';';
-    }
+      if ( options.path ) {
+        cookieString += 'path=' + options.path + ';';
+      }
 
-    if ( domain ) {
-      cookieString += 'domain=' + domain + ';';
-    }
+      if ( options.domain ) {
+        cookieString += 'domain=' + options.domain + ';';
+      }
 
-    if ( secure ) {
-      cookieString += 'secure;';
-    }
+      if ( options.secure ) {
+        cookieString += 'secure;';
+      }
 
-    if ( sameSite ) {
-      cookieString += 'sameSite=' + sameSite + ';';
+      if ( options.sameSite ) {
+        cookieString += 'sameSite=' + options.sameSite + ';';
+      }
     }
 
     this.document.cookie = cookieString;
@@ -143,7 +138,13 @@ export class CookieService {
       return;
     }
 
-    this.set( name, '', new Date('Thu, 01 Jan 1970 00:00:01 GMT'), path, domain );
+    const options: CookieOptions = {
+      expires: new Date('Thu, 01 Jan 1970 00:00:01 GMT'),
+      path: path,
+      domain: domain
+    };
+
+    this.set( name, '', options );
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     },
     {
       "name": "DBaker85"
+    },
+    {
+      "name": "alessioferrero"
     }
   ],
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-cookie-service",
   "description": "an (aot ready) angular (4.2+) cookie service",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": "7leads GmbH <info@7leads.org>",
   "keywords": [


### PR DESCRIPTION
Hey!

I was in the process of implementing this package but found it frustrating because the only parameters I cared about when setting a cookie were `secure` and `sameSite`. This wouldn't be an issue if Typescript had named parameters (which I don't think is possible due to JavaScript limitations). But this resulted in a lot of my code looking like:

`this.cookieService.set('token', val', undefined, undefined, undefined, true, 'Strict');`

which is hard to read without looking at the methods signature, and can also be error prone if repeated.

In addition to this, my application needs to make several calls to `set` with the same configuration (`secure: true, sameSite: Strict`), and whilst this could be abstracted away in my application, I think it would be cleaner if I had the option to create a constant CookieOptions instance which could be passed in to all calls to the `set` method.

I've tried to stick to your style guide and I appreciate any feedback on this issue. I understand if you're reluctant to release this as it would be a breaking change which would require a package increase to 3.0.0.

(I am currently unable to test if this works properly since I cannot get your project to compile, `scripts/compile.js` throws errors for me when trying to run `yarn && yarn run compile`, so I apologise if there are any initial issues with this PR)


Thank you!
Alessio