### PR TITLE
Add `NgModule` To Provide `CookieService`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.0
+- add `CookieModule`
+
 # 2.1.0
 - add `SameSite` support
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install ngx-cookie-service --save
 yarn add ngx-cookie-service
 ```
 
-Add the cookie service to your `app.module.ts` as a provider:
+Add the cookie module to your `app.module.ts` as an import:
 
 ```typescript
 import { BrowserModule } from '@angular/platform-browser';
@@ -21,12 +21,11 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { AppComponent } from './app.component';
-import { CookieService } from 'ngx-cookie-service';
+import { CookieModule } from 'ngx-cookie-service';
 
 @NgModule({
   declarations: [ AppComponent ],
-  imports: [ BrowserModule, FormsModule, HttpModule ],
-  providers: [ CookieService ],
+  imports: [ BrowserModule, FormsModule, HttpModule, CookieModule ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule { }
@@ -181,6 +180,7 @@ Thanks to all contributors:
 * [flakolefluk](https://github.com/flakolefluk)
 * [mattbanks](https://github.com/mattbanks)
 * [DBaker85](https://github.com/DBaker85)
+* [swseverance](https://github.com/swseverance)
 
 # License
 

--- a/README_NPM.md
+++ b/README_NPM.md
@@ -12,7 +12,7 @@ npm install ngx-cookie-service --save
 yarn add ngx-cookie-service
 ```
 
-Add the cookie service to your `app.module.ts` as a provider:
+Add the cookie module to your `app.module.ts` as an import:
 
 ```typescript
 import { BrowserModule } from '@angular/platform-browser';
@@ -21,12 +21,11 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { AppComponent } from './app.component';
-import { CookieService } from 'ngx-cookie-service';
+import { CookieModule } from 'ngx-cookie-service';
 
 @NgModule({
   declarations: [ AppComponent ],
-  imports: [ BrowserModule, FormsModule, HttpModule ],
-  providers: [ CookieService ],
+  imports: [ BrowserModule, FormsModule, HttpModule, CookieModule ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule { }
@@ -120,6 +119,19 @@ Are you having any trouble with your integration or cookies in general? Check ou
 This cookie service is brought to you by [7leads GmbH](http://www.7leads.org/). We built it for one of our apps, because the other cookie packages we found were either not designed "the Angular way" or caused trouble during AOT compilation.
 
 Check out the [GitHub page](https://github.com/7leads/ngx-cookie-service) for more.
+
+# Contributors
+
+Thanks to all contributors:
+
+* [paroe](https://github.com/paroe)
+* [CunningFatalist](https://github.com/CunningFatalist)
+* [kthy](https://github.com/kthy)
+* [JaredClemence](https://github.com/JaredClemence)
+* [flakolefluk](https://github.com/flakolefluk)
+* [mattbanks](https://github.com/mattbanks)
+* [DBaker85](https://github.com/DBaker85)
+* [swseverance](https://github.com/swseverance)
 
 # License
 

--- a/demo-app/app/app.component.spec.ts
+++ b/demo-app/app/app.component.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed, async, inject } from '@angular/core/testing';
 
 import { AppComponent } from './app.component';
-import { CookieService } from '../../lib';
+import { CookieService, CookieModule } from '../../lib';
 
 describe('CookieService', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AppComponent ],
-      providers: [ CookieService ]
+      imports: [ CookieModule ]
     }).compileComponents();
   }));
 

--- a/demo-app/app/app.module.ts
+++ b/demo-app/app/app.module.ts
@@ -4,12 +4,11 @@ import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
 import { AppComponent } from './app.component';
-import { CookieService } from '../../lib';
+import { CookieModule } from '../../lib';
 
 @NgModule({
   declarations: [ AppComponent ],
-  imports: [ BrowserModule, FormsModule, HttpModule ],
-  providers: [ CookieService ],
+  imports: [ BrowserModule, FormsModule, HttpModule, CookieModule ],
   bootstrap: [ AppComponent ]
 })
 export class AppModule {}

--- a/lib/cookie-module/cookie.module.ts
+++ b/lib/cookie-module/cookie.module.ts
@@ -1,0 +1,8 @@
+import { NgModule } from '@angular/core';
+
+import { CookieService } from '../cookie-service/cookie.service';
+
+@NgModule({
+  providers: [ CookieService ]
+})
+export class CookieModule {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './cookie-service/cookie.service';
+export * from './cookie-module/cookie.module';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngx-cookie-service",
   "description": "an (aot ready) angular (4.2+) cookie service",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "author": "7leads GmbH <info@7leads.org>",
   "keywords": [
@@ -48,6 +48,9 @@
     },
     {
       "name": "DBaker85"
+    },
+    {
+      "name": "Sam Severance"
     }
   ],
   "main": "index.js",


### PR DESCRIPTION
* This PR creates a `CookieModule` in which the `CookieService`
  is provided. Users are encouraged to add `CookieModule` to the
  `imports` section of an `NgModule` as opposed to adding `CookieService`
  to the `providers` section. However, adding `CookieService` as a
  provider will still work, so existing users of the library won't be
  required to make any changes.